### PR TITLE
Set KillBill github packages repository to find qualpay-java-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
         <system>Github</system>
         <url>https://github.com/killbill/killbill-qualpay-plugin/issues</url>
     </issueManagement>
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/killbill/*</url>
+        </repository>
+    </repositories>
     <properties>
     </properties>
     <dependencies>


### PR DESCRIPTION
Out of the box project isn't build because qualpay-java-client library not placed in m2 or central, the plugin building is requiring to execute goal 'install' for qualpay-java-client for correct resolve dependency from maven local.