### PR TITLE
update pom as follow up of killbill-client-java/124

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,8 +9,10 @@
         <module name="qualpay-plugin" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel>
-      <module name="qualpay-plugin" target="1.8" />
-    </bytecodeTargetLevel>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="qualpay-plugin" options="-parameters -XDignore.symbol.file" />
+    </option>
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -65,23 +65,24 @@ This PAT guide is valid at the time of writing. It may change, but the idea is t
 
 #### Create settings.xml
 
-1. Create `settings.xml` in the root of project directory, with content:
-```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <servers>
-        <server>
-            <id>github</id>
-            <username>{your-username}</username>
-            <!-- Public token with `read:packages` scope -->
-            <password>{generated-token-from-github}</password>
-        </server>
-    </servers>
-</settings>
-```
+Create `settings.xml` in the root of project directory (or add to `<M2_HOME>/settings.xml`):
+   ```xml
+   <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+     <servers>
+       <server>
+         <id>github</id>
+         <username>{your-username}</username>
+         <!-- Public token with `read:packages` scope -->
+         <password>{generated-token-from-github}</password>
+       </server>
+     </servers>
+   </settings>
+   ```
 
-2. We already have `.mvn/maven.config` file, so maven will pick `settings.xml` file above automatically.
+If `settings.xml` exist in your project root directory, use maven with `--settings` option like: 
+`mvn --settings settings.xml clean install -Dgroups=slow`.
 
 ### Regenerate JOOQ classes
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>qualpay-plugin</artifactId>
     <version>1.0.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>qualpay-plugin</name>
+    <name>Kill Bill OSGI Qualpay plugin</name>
     <description>Kill Bill Qualpay plugin</description>
     <url>http://github.com/killbill/killbill-qualpay-plugin</url>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -15,45 +15,56 @@
   ~ License for the specific language governing permissions and limitations
   ~ under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.146.6</version>
+        <artifactId>killbill-oss-parent</artifactId>
+        <version>0.146.16</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>qualpay-plugin</artifactId>
-    <name>Kill Bill OSGI Qualpay plugin</name>
     <version>1.0.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
+    <name>qualpay-plugin</name>
     <description>Kill Bill Qualpay plugin</description>
     <url>http://github.com/killbill/killbill-qualpay-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-qualpay-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-qualpay-plugin.git</developerConnection>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill-qualpay-plugin/tree/master</url>
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
     <issueManagement>
         <system>Github</system>
         <url>https://github.com/killbill/killbill-qualpay-plugin/issues</url>
     </issueManagement>
-    <repositories>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/killbill/*</url>
-        </repository>
-    </repositories>
     <properties>
-    	<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+        <osgi.private>org.killbill.billing.plugin.qualpay.*</osgi.private>
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.kill-bill.billing.thirdparty</groupId>
-            <artifactId>qualpay-java-client</artifactId>
-            <version>1.1.9</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.57</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -61,54 +72,64 @@
             <version>2.10</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>2.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-money</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.billing.plugin</groupId>
-            <artifactId>killbill-plugin-api-payment</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.billing.plugin</groupId>
-            <artifactId>killbill-plugin-api-notification</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.billing.plugin.java</groupId>
-            <artifactId>killbill-base-plugin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.billing.plugin.java</groupId>
-            <artifactId>killbill-base-plugin</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.commons</groupId>
-            <artifactId>killbill-clock</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.commons</groupId>
-            <artifactId>killbill-clock</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.billing</groupId>
-            <artifactId>killbill-platform-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
@@ -119,20 +140,66 @@
             <artifactId>killbill-platform-osgi-bundles-lib-killbill</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-platform-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing.plugin</groupId>
+            <artifactId>killbill-plugin-api-notification</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing.plugin</groupId>
+            <artifactId>killbill-plugin-api-payment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing.plugin.java</groupId>
+            <artifactId>killbill-base-plugin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing.plugin.java</groupId>
+            <artifactId>killbill-base-plugin</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing.thirdparty</groupId>
+            <artifactId>qualpay-java-client</artifactId>
+            <version>1.1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-clock</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-clock</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-mysql</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>org.kill-bill.testing</groupId>
+            <artifactId>testing-mysql-server</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <scope>provided</scope>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -144,195 +211,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>1.57</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>2.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.framework</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.commons</groupId>
-            <artifactId>killbill-embeddeddb-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.joda</groupId>
-            <artifactId>joda-money</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kill-bill.testing</groupId>
-            <artifactId>testing-mysql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.zonky.test</groupId>
-            <artifactId>embedded-postgres</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jooby</groupId>
-            <artifactId>jooby</artifactId>
-        </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/killbill/*</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <!-- Do not add <goal>jar</goal> here: https://stackoverflow.com/a/40964626/554958 -->
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <archive>
-                                <!-- use the manifest file created by the bundle plugin -->
-                                <!--<useDefaultManifestFile>true</useDefaultManifestFile>-->
-                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                                <!-- bundle plugin already generated the maven descriptor -->
-                                <addMavenDescriptor>false</addMavenDescriptor>
-                            </archive>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-Activator>org.killbill.billing.plugin.qualpay.QualpayActivator</Bundle-Activator>
-                        <Export-Package>
-                            org.killbill.billing.plugin.service
-                        </Export-Package>
-                        <Private-Package>org.killbill.billing.plugin.qualpay.*</Private-Package>
-                        <!-- Optional resolution because exported by the Felix system bundle -->
-                        <Import-Package>
-                            org.joda.time;
-                            org.joda.time.format;
-                            org.killbill.billing.account.api;
-                            org.killbill.billing.catalog.api;
-                            org.killbill.billing.invoice.api;
-                            org.killbill.billing.entitlement.api;
-                            org.killbill.billing.notification.api;
-                            org.killbill.billing.notification.plugin.api;
-                            org.killbill.billing.notification.plugin;
-                            org.killbill.billing.osgi.api;
-                            org.killbill.billing.osgi.api.config;
-                            org.killbill.billing.payment.api;
-                            org.killbill.billing.payment.plugin.api;
-                            org.killbill.billing.control.plugin.api;
-                            org.killbill.billing.tenant.api;
-                            org.killbill.billing.usage.api;
-                            org.killbill.billing.util.api;
-                            org.killbill.billing.currency.plugin.api;
-                            org.killbill.billing.currency.api;
-                            org.killbill.billing.security.api;
-                            org.xml.sax.ext;
-                            org.xml.sax.helpers;
-                            org.xml.sax;
-                            org.w3c.dom;
-                            org.w3c.dom.ls;
-                            javax.net.ssl;
-                            javax.management;
-                            javax.jws.soap;
-                            javax.annotation;
-                            javax.naming.directory;
-                            javax.naming.event;
-                            javax.naming.ldap;
-                            javax.naming.spi;
-                            javax.naming;
-                            sun.misc;
-                            sun.misc.unsafe;
-                            sun.security;
-                            sun.security.util;
-                            org.osgi.service.log;
-                            version="[0,3)",
-                            *;resolution:=optional
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>assemble-killbill-osgi-bundles-qualpay-plugin</id>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <createSourcesJar>true</createSourcesJar>
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                            <filters>
-                                <filter>
-                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
As we found a problem in https://github.com/killbill/killbill-client-java/issues/124, I inspect almost every project that contains `maven-shade-plugin`. This one use it, but as Pierre told me, this plugin supposed to be not use shade plugin anymore, as almost configuration (mostly has something to-do with OSGI) move away to `killbill-oss-parent`. 

- [This commit](https://github.com/killbill/killbill-qualpay-plugin/commit/810d1a51787ad47431ac0d45b4c6e60a196220c8) has nothing to do with `killbill-client-java/124`, but just intellij config that still ask user to use Java 8.
- [Commit in pom.xml](https://github.com/killbill/killbill-qualpay-plugin/commit/3536444539fb9e18d85d1d52b62b5957b34c1ed5) seems contains a lot of changes, but most of them (automatic) re-format. Some important things are: 
    - change in [plugins declaration](https://github.com/killbill/killbill-qualpay-plugin/compare/update-plugins?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R227), and
    - add [osgi.private](https://github.com/killbill/killbill-qualpay-plugin/compare/update-plugins?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R44)